### PR TITLE
issue #52 CHATGpt wrapper UI improvements

### DIFF
--- a/client/src/components/GptWrapper.jsx
+++ b/client/src/components/GptWrapper.jsx
@@ -1,41 +1,30 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import axios from 'axios';
-import "../App.css"
+import "../App.css";
+import "../css/GptWrapper.css";
 
-// CHANGE: Added helper to pretty-print JSON and copy to clipboard
+// Pretty-print helper (unchanged)
 const stringifyPretty = (obj) => {
   if (obj == null) return '';
   if (typeof obj === 'string') {
-    // If backend returned a JSON-encoded string, try to parse once
     try {
       const parsed = JSON.parse(obj);
       if (typeof parsed === 'string') return parsed;
-    } catch {
-      // not JSON-encoded; fall through
-    }
-    // Reveal common escape sequences so \\n renders as a real newline in <pre>
-    return obj
-      .replaceAll('\\r\\n', '\n')
-      .replaceAll('\\n', '\n')
-      .replaceAll('\\t', '\t');
+    } catch {}
+    return obj.replaceAll('\\r\\n', '\n').replaceAll('\\n', '\n').replaceAll('\\t', '\t');
   }
-  try {
-    return JSON.stringify(obj, null, 2);
-  } catch {
-    return String(obj);
-  }
+  try { return JSON.stringify(obj, null, 2); } catch { return String(obj); }
 };
 
-export function Form() {
+export default function GptWrapper() {
   const [input, setInput] = useState('');
   const [loading, setLoading] = useState(false);
-  const [responseData, setResponseData] = useState(null);
+  const [responseData, setResponseData] = useState(null); // kept for compatibility
   const [error, setError] = useState(null);
-  const [copied, setCopied] = useState(false); // CHANGE: copy feedback state
+  const [copied, setCopied] = useState(false); // kept
+  const [history, setHistory] = useState([]);  // [{ role: 'user'|'assistant', content: string }]
 
-  // Session memory (current page session persisted in localStorage)
-  const [history, setHistory] = useState([]); // [{ role: 'user'|'assistant', content: string }]
-
+  // Load saved history
   useEffect(() => {
     try {
       const raw = localStorage.getItem('gpt_history');
@@ -43,13 +32,12 @@ export function Form() {
         const parsed = JSON.parse(raw);
         if (Array.isArray(parsed)) setHistory(parsed);
       }
-    } catch { }
+    } catch {}
   }, []);
 
+  // Persist history
   useEffect(() => {
-    try {
-      localStorage.setItem('gpt_history', JSON.stringify(history));
-    } catch { }
+    try { localStorage.setItem('gpt_history', JSON.stringify(history)); } catch {}
   }, [history]);
 
   const handleCopy = async () => {
@@ -66,7 +54,26 @@ export function Form() {
     setHistory([]);
     setResponseData(null);
     setError(null);
+    setInput('');
   };
+
+  // Auto-grow textarea
+  const taRef = useRef(null);
+  const autoResize = () => {
+    const el = taRef.current;
+    if (!el) return;
+    el.style.height = 'auto';
+    const maxPx = 8 * 28 + 28; // cap ~8 lines
+    el.style.height = Math.min(el.scrollHeight, maxPx) + 'px';
+  };
+  useEffect(autoResize, [input]);
+
+  // Auto-scroll to bottom on new messages
+  const listRef = useRef(null);
+  useEffect(() => {
+    const el = listRef.current;
+    if (el) el.scrollTop = el.scrollHeight;
+  }, [history, loading]);
 
   const handleSubmit = async (e) => {
     e.preventDefault();
@@ -75,30 +82,23 @@ export function Form() {
     setError(null);
     setResponseData(null);
 
-    // Append the user turn to a working copy of history (limit to last 8 turns to keep payload small)
     const nextHistoryUser = [...history, { role: 'user', content: input }];
     const recentHistory = nextHistoryUser.slice(-8);
 
     try {
       const response = await axios.post(
-        'http://localhost:8080/api/ai/complete',
-        { question: input, history: recentHistory },
-        {
-          headers: {
-            'Content-Type': 'text/plain', // preserve existing contract
-          },
-        }
+        'http://localhost:8080/api/ai/complete',        // unchanged endpoint
+        { question: input, history: recentHistory },    // unchanged payload
+        { headers: { 'Content-Type': 'text/plain' } }   // unchanged header
       );
 
-      setResponseData(response.data);
+      setResponseData(response.data); // kept
 
-      // Stringify into readable text for transcript storage
       const assistantText = stringifyPretty(response.data);
       setHistory([...nextHistoryUser, { role: 'assistant', content: assistantText }]);
       setInput('');
     } catch (err) {
       setError(err.response?.data?.message || 'Something went wrong.');
-      // Still commit the user message so transcript reflects the attempt
       setHistory(nextHistoryUser);
     } finally {
       setLoading(false);
@@ -106,124 +106,82 @@ export function Form() {
   };
 
   return (
-    // CHANGE: modern container and card styling with subtle glass effect
-    <div className="w-full max-w-2xl mx-auto p-4 sm:p-6">
-      <div className="rounded-2xl border border-slate-200/70 bg-white/80 shadow-xl backdrop-blur supports-[backdrop-filter]:bg-white/70">
-        <div className="mx-auto max-w-xl text-left">
-          {/* Header */}
-          {/* CHANGE: cleaner header with icon and helper text */}
-          <div className="p-5 sm:p-6 text-left">
-            <div className="flex items-center gap-3">
-              <div>
-                <h3 className="text-2xl font-semibold tracking-tight text-slate-900">Ask Chat…</h3>
-                <p className="text-sm text-slate-600">What's on your mind today? Talk to the almighty GPT wrapper.</p>
-              </div>
-            </div>
-          </div>
-
-          {/* Transcript (session memory) */}
-          {history.length > 0 && (
-            <div className="px-5 sm:px-6 pb-3">
-              <div className="mb-2 flex items-center gap-2">
-                <p className="text-sm font-medium text-slate-700">Current session</p>
-                <button
-                  type="button"
-                  onClick={handleReset}
-                  className="ml-auto inline-flex items-center rounded-lg border border-slate-300 bg-white/80 px-2.5 py-1.5 text-xs font-medium text-slate-700 shadow-sm hover:bg-white focus:outline-none focus-visible:ring-4 focus-visible:ring-slate-300/50"
-                >
-                  Reset chat
-                </button>
-              </div>
-              <div className="rounded-xl border border-slate-200 bg-white/80 shadow-inner max-h-56 overflow-auto p-3 space-y-2">
-                {history.map((m, idx) => (
-                  <div key={idx} className={m.role === 'user' ? 'text-slate-900' : 'text-slate-800'}>
-                    <div className="mb-1 inline-flex items-center gap-2 text-xs font-semibold uppercase tracking-wide">
-                      <span className={m.role === 'user' ? 'text-indigo-700' : 'text-emerald-700'}>
-                        {m.role === 'user' ? 'You' : 'AI'}
-                      </span>
-                      <span className="text-slate-400">•</span>
-                      <span className="text-slate-500">Turn {idx + 1}</span>
-                    </div>
-                    <pre className="whitespace-pre-wrap break-words text-sm leading-relaxed" style={{ overflowWrap: 'anywhere', wordBreak: 'break-word', margin: 0 }}>
-                      {m.content}
-                    </pre>
-                  </div>
-                ))}
-              </div>
-            </div>
-          )}
-
-          {/* Form */}
-          {/* CHANGE: one-column layout, large target textarea, clear focus/hover/disabled states */}
-          <form onSubmit={handleSubmit} className="px-5 pb-5 sm:px-6 sm:pb-6 space-y-4 text-left" aria-describedby="helper-text">
-            <label htmlFor="gpt-input" className="sr-only">Your question</label>
-            <br></br>
-            <textarea
-              id="gpt-input"
-              value={input}
-              onChange={(e) => setInput(e.target.value)}
-              placeholder="Ask me anything…"
-              rows={4}
-              className="w-full max-w-full rounded-2xl border border-slate-300 bg-white px-4 py-3 text-base leading-relaxed shadow-sm placeholder:text-slate-400 focus:border-indigo-500 focus:outline-none focus:ring-4 focus:ring-indigo-500/20 disabled:opacity-60"
-              disabled={loading}
-            />
-            <div id="helper-text" className="text-xs text-slate-500">Press submit or keep typing to refine your prompt.</div>
-
-            <div className="flex items-center gap-3">
-              {/* CHANGE: modern primary button with loading spinner */}
-              <button
-                type="submit"
-                disabled={loading || !input.trim()}
-                className="inline-flex items-center justify-center rounded-2xl bg-slate-900 px-5 py-3 text-sm font-medium text-white shadow hover:bg-slate-800 focus:outline-none focus-visible:ring-4 focus-visible:ring-slate-900/30 disabled:cursor-not-allowed disabled:opacity-50"
-              >
-                {loading && (
-                  <svg className="mr-2 h-4 w-4 animate-spin" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                    <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
-                    <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z" />
-                  </svg>
-                )}
-                {loading ? 'Submitting…' : 'Submit'}
-              </button>
-
-              {/* CHANGE: subtle character count */}
-              <span className="ml-auto text-xs text-slate-500" style={{ paddingLeft: 10 }}>{input.length} chars</span>
-            </div>
-          </form>
-
-          {/* Feedback Area */}
-          <div className="px-5 pb-5 sm:px-6 sm:pb-6 space-y-4">
-            {/* CHANGE: styled success panel for response */}
-            {responseData && (
-              <div className="rounded-2xl border border-emerald-200/80 bg-emerald-50 p-4 text-emerald-900 shadow-sm">
-                <div className="mb-2 flex items-center justify-between">
-                  <p className="font-semibold">AI Response</p>
-                  <div className="flex items-center gap-2">
-                  </div>
-                </div>
-                <pre
-                  className="w-full max-h-72 overflow-auto rounded-xl bg-white/90 p-3 text-sm leading-relaxed shadow-inner whitespace-pre-wrap break-words"
-                  style={{ overflowWrap: "anywhere", wordBreak: "break-word" }}
-                >
-                  {stringifyPretty(responseData)}
-                </pre>
-                {/* CHANGE: polite live region for screen readers */}
-                <div className="sr-only" role="status" aria-live="polite">Response loaded</div>
-              </div>
-            )}
-
-            {/* CHANGE: styled error panel */}
-            {error && (
-              <div className="rounded-2xl border border-red-200 bg-red-50 p-4 text-red-900 shadow-sm">
-                <p className="font-semibold">Request failed</p>
-                <p className="mt-1 text-sm">{error}</p>
-                <div className="sr-only" role="status" aria-live="assertive">An error occurred</div>
-              </div>
-            )}
-          </div>
-        </div>
+    <div className="gptw-card">
+      {/* Header: left-focused */}
+      <div className="gptw-header">
+        <h3>Ask Chat…</h3>
+        <p>What's on your mind today? Talk to the almighty GPT wrapper.</p>
       </div>
+
+      {/* Error banner (only if error) */}
+      {error && (
+        <div className="gptw-error">
+          <strong>Request failed:</strong>&nbsp;<span>{error}</span>
+        </div>
+      )}
+
+      {/* Messages list */}
+      <div ref={listRef} className="gptw-list">
+        {history.length === 0 && (
+          <div className="gptw-empty">Start the conversation below.</div>
+        )}
+
+        {history.map((m, idx) => {
+          const isUser = m.role === 'user';
+          return (
+            <div
+              key={idx}
+              className={`gptw-row ${isUser ? 'gptw-right' : 'gptw-left'}`}
+            >
+              {/* USER = right bubble, BOT = plain left text */}
+              <div className={`gptw-bubble ${isUser ? 'user' : 'bot'}`}>
+                {m.content}
+              </div>
+
+              {/* Tail only for user (right side) */}
+              {isUser && <span className="gptw-tail" aria-hidden="true" />}
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Composer sticks to bottom of wrapper */}
+      <form onSubmit={handleSubmit} className="gptw-composer">
+        <label htmlFor="gpt-input" className="sr-only">Your question</label>
+        <textarea
+          id="gpt-input"
+          ref={taRef}
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          onInput={autoResize}
+          placeholder="Ask me anything…"
+          rows={5}
+          className="gptw-input"
+          disabled={loading}
+        />
+
+        {/* Reset left, Submit right */}
+        <div className="gptw-actions gptw-actions-split">
+          <button
+            type="button"
+            onClick={handleReset}
+            disabled={loading}
+            className="gptw-btn secondary"
+            aria-label="Reset chat"
+          >
+            Reset chat
+          </button>
+
+          <button
+            type="submit"
+            disabled={loading || !input.trim()}
+            className="gptw-btn primary"
+            aria-label="Submit message"
+          >
+            {loading ? 'Submitting…' : 'Submit'}
+          </button>
+        </div>
+      </form>
     </div>
   );
 }
-
-export default Form;

--- a/client/src/css/GptWrapper.css
+++ b/client/src/css/GptWrapper.css
@@ -1,0 +1,181 @@
+/* Container fits the widget area — not full screen */
+.gptw-card {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;            /* fill the Widget box */
+  background: rgba(255,255,255,0.06);
+  border: 1px solid rgba(216,219,224,0.2);
+  border-radius: 14px;
+  box-shadow: 0 10px 24px rgba(0,0,0,0.2);
+  overflow: hidden;        /* keep inner edges clean */
+}
+
+/* Header: left-focused */
+.gptw-header {
+  text-align: left;
+  padding: 18px 18px 8px;
+}
+.gptw-header h3 {
+  margin: 0;
+  font-size: 22px;         /* not huge so it fits */
+  font-weight: 700;
+}
+.gptw-header p {
+  margin: 6px 0 0;
+  opacity: 0.85;
+  font-size: 14px;
+}
+
+/* Optional error banner */
+.gptw-error {
+  border: 1px solid rgba(239, 68, 68, 0.4); /* red-500/40 */
+  background: rgba(239, 68, 68, 0.15);      /* red-500/15 */
+  color: #e5e7eb;                            /* slate-200 */
+  border-radius: 12px;
+  padding: 0.75rem;
+}
+
+
+/* Messages list */
+.gptw-list {
+  flex: 1;
+  overflow-y: auto;
+  padding: 8px 14px 12px;
+  display: flex;
+  flex-direction: column;
+  row-gap: 18px;           /* space between turns */
+}
+
+/* Empty state */
+.gptw-empty {
+  text-align: left;
+  opacity: 0.7;
+  font-size: 14px;
+  padding: 8px 2px;
+}
+
+/* One row per message */
+.gptw-row {
+  display: flex;
+  width: 100%;
+}
+.gptw-right { justify-content: flex-end; }
+.gptw-left  { justify-content: flex-start; }
+
+/* Message visuals */
+.gptw-bubble {
+  max-width: 82%;
+  white-space: pre-wrap;
+  word-break: break-word;
+  line-height: 1.6;
+  font-size: 1.05rem;      /* comfy read size */
+}
+
+/* USER: right bubble (darker than background) */
+.gptw-bubble.user {
+background: #3b3f4a;          /* grey bubble */
+  color: #f1f5f9;
+  padding: 12px 16px;
+  border-radius: 16px;
+  border-bottom-right-radius: 6px;
+  box-shadow: 0 2px 8px rgba(0,0,0,.15);
+  position: relative;
+}
+
+/* BOT: left plain text — no bubble background */
+.gptw-bubble.bot {
+  background: transparent;
+  color: #e5e7ea;          /* readable on dark bg */
+  padding: 0;              /* plain text look */
+}
+
+/* Little tail for the user bubble */
+.gptw-tail {
+  position: relative;
+  right: 8px;
+  bottom: -6px;
+  width: 8px;
+  height: 8px;
+  background: #4f46e5;
+  display: inline-block;
+  transform: rotate(45deg);
+  border-bottom-right-radius: 2px;
+}
+
+/* Composer sticks to bottom */
+.gptw-composer {
+  border-top: 1px solid rgba(216,219,224,0.18);
+  padding: 10px 14px 14px;
+  background: rgba(18,18,18,0.35);
+}
+
+/* Input (auto-resizes via JS) */
+.gptw-input {
+  width: 100%;
+  min-height: 96px;       /* starts larger */
+  max-height: 240px;
+  font-size: 1.05rem;
+  line-height: 1.6;
+  padding: 12px 14px;
+  border-radius: 12px;
+  border: 1px solid rgba(147,163,184,0.35);
+  background: #0f172a;    /* darker than bg */
+  color: #e5e7ea;
+  resize: none;
+  outline: none;
+}
+.gptw-input::placeholder { color: #9ba3af; }
+
+/* Actions row: reset left, submit right */
+.gptw-actions {
+  margin-top: 10px;
+  display: flex;
+  gap: 10px;
+}
+.gptw-actions-split {
+  justify-content: space-between; /* left / right */
+}
+
+/* Buttons */
+.gptw-btn {
+  appearance: none;
+  border: 0;
+  border-radius: 12px;
+  padding: 10px 16px;
+  font-weight: 700;
+  font-size: 0.95rem;
+  cursor: pointer;
+}
+.gptw-btn.primary {
+  background: #0f172a;
+  color: #fff;
+}
+.gptw-btn.primary:disabled { opacity: .6; cursor: not-allowed; }
+.gptw-btn.secondary {
+  background: transparent;
+  color: #e5e7ea;
+  border: 1px solid rgba(147,163,184,0.35);
+}
+
+.gptw-card,
+.gptw-header,
+.gptw-list,
+.gptw-row,
+.gptw-bubble {
+  text-align: left !important;
+}
+
+/* keep bot rows anchored left */
+.gptw-row.gptw-left {
+  justify-content: flex-start !important;
+}
+
+/* make AI (bot) messages left-aligned text, no centering */
+.gptw-bubble.bot {
+  display: inline-block;
+  padding: 0;
+  background: transparent;
+  color: #e5e7ea;
+  text-align: left !important;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,12 +13,11 @@
         "@testing-library/react": "^16.3.0",
         "@testing-library/user-event": "^14.6.1",
         "axios": "^1.12.0",
-        "concurrently": "9.2.0",
         "jsdom": "^26.1.0",
         "vitest": "^3.2.4"
       },
       "devDependencies": {
-        "concurrently": "9.2.0"
+        "concurrently": "^9.2.0"
       }
     },
     "client": {
@@ -3995,13 +3994,13 @@
       "license": "MIT"
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.14",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz",
-      "integrity": "sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==",
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
       "license": "MIT",
       "dependencies": {
-        "fdir": "^6.4.4",
-        "picomatch": "^4.0.2"
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -4126,17 +4125,17 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.1.2.tgz",
-      "integrity": "sha512-J0SQBPlQiEXAF7tajiH+rUooJPo0l8KQgyg4/aMunNtrOa7bwuZJsJbDWzeljqQpgftxuq5yNJxQ91O9ts29UQ==",
+      "version": "7.1.9",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.1.9.tgz",
+      "integrity": "sha512-4nVGliEpxmhCL8DslSAUdxlB6+SMrhB0a1v5ijlh1xB1nEPuy1mxaHxysVucLHuWryAxLWg6a5ei+U4TLn/rFg==",
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.25.0",
-        "fdir": "^6.4.6",
+        "fdir": "^6.5.0",
         "picomatch": "^4.0.3",
         "postcss": "^8.5.6",
         "rollup": "^4.43.0",
-        "tinyglobby": "^0.2.14"
+        "tinyglobby": "^0.2.15"
       },
       "bin": {
         "vite": "bin/vite.js"

--- a/package.json
+++ b/package.json
@@ -10,14 +10,13 @@
     "client"
   ],
   "devDependencies": {
-    "concurrently": "9.2.0"
+    "concurrently": "^9.2.0"
   },
   "dependencies": {
-    "axios": "^1.12.0",
     "@testing-library/jest-dom": "^6.8.0",
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^14.6.1",
-    "concurrently": "9.2.0",
+    "axios": "^1.12.0",
     "jsdom": "^26.1.0",
     "vitest": "^3.2.4"
   }


### PR DESCRIPTION
ChatGPT wrapper UI refresh

Refactored styles for a cleaner, more consistent aesthetic and better readability.

User messages now render as right-aligned grey bubbles; assistant replies are left-aligned for a true “two-party chat” feel.

Fixed duplicate responses (API result is shown once only).

Enlarged, auto-growing message composer; supports scaling/resizing and improved line wrapping for long text.

Kept the composer docked at the bottom of the widget; Submit sits bottom-right and Reset chat bottom-left.

Removed nonessential helper text and labels to reduce clutter and cognitive load.

Increased base font sizes and spacing between turns to improve scanability.

Improved error banner with accessible contrast and consistent color treatment.

Made the layout responsive so the widget fits its grid cell and scales gracefully across screen sizes.

Added sensible defaults for word breaking, whitespace, and scroll behavior to prevent layout shift and keep the latest message in view.

Result: a simpler, more polished chat experience that reads like a real conversation, fits neatly inside the dashboard grid, and is easier to use on any screen.