### PR TITLE
Issue #49 - Refactored todo widget to be separated from Canvas integration

### DIFF
--- a/client/src/components/TodoWidget.jsx
+++ b/client/src/components/TodoWidget.jsx
@@ -1,17 +1,11 @@
-import React, { useEffect, useState, useRef } from "react";
+import React, { useState } from "react";
 import { createPortal } from "react-dom";
 
 function TodoWidget() {
-  // For hold-to-complete
-  const [holdId, setHoldId] = useState(null);
-  const [holdProgress, setHoldProgress] = useState(0);
-  const holdTimeout = useRef();
-  const holdInterval = useRef();
   const [fadingIds, setFadingIds] = useState([]);
   const [todos, setTodos] = useState([]);
-  const [loading, setLoading] = useState(false); 
+  const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
-  const [courseFilter, setCourseFilter] = useState("all");
   const [timeFilter, setTimeFilter] = useState("all");
   const [showModal, setShowModal] = useState(false);
   const [modalTitle, setModalTitle] = useState("");
@@ -19,20 +13,8 @@ function TodoWidget() {
   const [modalDescription, setModalDescription] = useState("");
   const [modalClass, setModalClass] = useState("");
 
-  // Assign a color to each course
-  const courseColors = {
-    "SOFTENG 310": "#f59e42",
-    "SOFTENG 306": "#60a5fa",
-    "SOFTENG 325": "#34d399",
-    "COMPSCI 367": "#a78bfa",
-    "(Custom)": "#e5e7eb"
-  };
-
   // Filtering logic
   let filtered = [...todos];
-  if (courseFilter !== "all") {
-    filtered = filtered.filter(t => t.course === courseFilter);
-  }
   if (timeFilter !== "all") {
     const now = new Date();
     let minDate = null, maxDate = null;
@@ -53,13 +35,6 @@ function TodoWidget() {
       });
     }
   }
-  // Only show incomplete todos
-  filtered = filtered.filter(t => !t.done);
-
-  // Unique course list for filter dropdown and add modal
-  const customCategories = ["daily", "reading", "sports"];
-  const courseList = ["all", ...Array.from(new Set(todos.map(t => t.course).filter(Boolean).concat(customCategories)))];
-  const addCategoryList = Array.from(new Set(todos.map(t => t.course).filter(Boolean).concat(customCategories)));
 
   const toggleTodo = (id) => {
     // If already fading, ignore
@@ -78,12 +53,9 @@ function TodoWidget() {
     }
   };
 
-  // Only allow deleting custom todos (source !== 'canvas')
+  // Always allow deleting (remove Canvas restriction)
   const deleteTodo = (id) => {
-    setTodos((prev) => prev.filter(t => {
-      const todo = prev.find(t2 => t2.id === id);
-      return todo && todo.source === "canvas" ? true : t.id !== id;
-    }));
+    setTodos(prev => prev.filter(t => t.id !== id));
   };
 
   if (loading) return <div>Loading tasks...</div>;
@@ -91,6 +63,16 @@ function TodoWidget() {
 
   return (
     <div style={{ maxWidth: 800, margin: '0 auto', padding: '0 16px' }}>
+      {/* Obvious done/undone animations */}
+      <style>
+        {`
+          @keyframes check-pop {
+            0% { transform: scale(0.6); opacity: 0; }
+            60% { transform: scale(1.15); opacity: 1; }
+            100% { transform: scale(1); opacity: 1; }
+          }
+        `}
+      </style>
       {/* Responsive controls: Add button on top if not enough space */}
       <div style={{ display: 'flex', flexDirection: 'column', gap: 6, marginBottom: 10 }}>
         <div style={{ display: 'flex', justifyContent: 'flex-start' }}>
@@ -107,33 +89,6 @@ function TodoWidget() {
           }}>Add</button>
         </div>
         <div style={{ display: 'flex', gap: 10, alignItems: 'center', flexWrap: 'wrap' }}>
-          <select value={courseFilter} onChange={e => setCourseFilter(e.target.value)}
-            style={{
-              fontSize: 13,
-              minWidth: 110,
-              maxWidth: 180,
-              padding: '4px 8px',
-              borderRadius: 5,
-              border: '1.5px solid #e5e7eb',
-              appearance: 'auto',
-              WebkitAppearance: 'auto',
-              MozAppearance: 'auto',
-              background: '#f9fafb',
-              color: '#22223b',
-              outline: 'none',
-              cursor: 'pointer',
-              transition: 'border 0.2s, box-shadow 0.2s',
-              whiteSpace: 'nowrap',
-              overflow: 'hidden',
-              textOverflow: 'ellipsis',
-            }}
-            onFocus={e => e.target.style.border = '1.5px solid #6366f1'}
-            onBlur={e => e.target.style.border = '1.5px solid #cbd5e1'}
-          >
-            {courseList.map(c => (
-              <option key={c} value={c}>{c === "all" ? "All Courses" : c}</option>
-            ))}
-          </select>
           <select value={timeFilter} onChange={e => setTimeFilter(e.target.value)}
             style={{
               fontSize: 13,
@@ -284,13 +239,13 @@ function TodoWidget() {
                     display: "flex",
                     alignItems: "flex-start",
                     marginBottom: 12,
-                    background: todo.done ? "#e0f2fe" : courseColors[todo.course] || "#fff",
+                    background: "#fff",
                     color: todo.done ? "#888" : "#222",
                     borderRadius: 10,
                     padding: 12,
                     boxShadow: "0 1px 4px rgba(0,0,0,0.04)",
                     position: "relative",
-                    transition: "background 0.2s, opacity 0.35s, transform 0.35s",
+                    transition: "opacity 0.35s, transform 0.35s",
                     opacity: fadingIds.includes(todo.id) ? 0 : 1,
                     transform: fadingIds.includes(todo.id) ? 'translateY(30px)' : 'translateY(0)',
                     pointerEvents: fadingIds.includes(todo.id) ? 'none' : 'auto',
@@ -298,35 +253,10 @@ function TodoWidget() {
                 >
                   <button
                     type="button"
-                    aria-label={todo.done ? "Completed" : "Mark as done"}
-                    onMouseDown={() => {
-                      if (todo.done) return;
-                      setHoldId(todo.id);
-                      setHoldProgress(0);
-                      let progress = 0;
-                      holdInterval.current = setInterval(() => {
-                        progress += 100 / 9; // 1s, 9 steps
-                        setHoldProgress(progress);
-                      }, 100);
-                      holdTimeout.current = setTimeout(() => {
-                        clearInterval(holdInterval.current);
-                        setHoldProgress(100);
-                        toggleTodo(todo.id);
-                        setHoldId(null);
-                      }, 1000);
-                    }}
-                    onMouseUp={() => {
-                      clearTimeout(holdTimeout.current);
-                      clearInterval(holdInterval.current);
-                      setHoldProgress(0);
-                      setHoldId(null);
-                    }}
-                    onMouseLeave={() => {
-                      clearTimeout(holdTimeout.current);
-                      clearInterval(holdInterval.current);
-                      setHoldProgress(0);
-                      setHoldId(null);
-                    }}
+                    role="checkbox"                       
+                    aria-checked={todo.done}              
+                    aria-label={todo.done ? "Mark as undone" : "Mark as done"}
+                    onClick={() => toggleTodo(todo.id)}
                     style={{
                       width: 36,
                       height: 36,
@@ -338,40 +268,40 @@ function TodoWidget() {
                       display: 'flex',
                       alignItems: 'center',
                       justifyContent: 'center',
-                      cursor: todo.done ? 'default' : 'pointer',
+                      cursor: 'pointer', // keep clickable even when done (for undo)
                       marginTop: 2,
                       marginRight: 12,
                       position: 'relative',
                       outline: 'none',
-                      transition: 'background 0.2s, border 0.2s',
-                      boxShadow: undefined,
+                      transition: 'transform 120ms ease, background 0.2s, border 0.2s, box-shadow 0.2s',
                       padding: 0,
                       overflow: 'visible',
+                      transform: todo.done ? 'scale(0.98)' : 'scale(1)',
+                      boxShadow: todo.done
+                        ? '0 0 0 3px rgba(34,197,94,0.25), 0 4px 10px rgba(0,0,0,0.08)'
+                        : '0 0 0 0 rgba(0,0,0,0)'
                     }}
-                    disabled={todo.done}
                   >
-                    {/* Green Tick icon SVG */}
-                    <svg width="20" height="20" viewBox="0 0 20 20" fill="none" stroke={todo.done ? '#fff' : '#22c55e'} strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" style={{ opacity: todo.done ? 1 : 0.8, display: 'block' }}>
+                    {/* Check icon: animated and high-contrast when done */}
+                    <svg
+                      width="20"
+                      height="20"
+                      viewBox="0 0 20 20"
+                      fill="none"
+                      stroke={todo.done ? '#fff' : '#94a3b8'}  
+                      strokeWidth={todo.done ? 2.8 : 2.2}
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      style={{
+                        display: 'block',
+                        opacity: todo.done ? 1 : 0.55,       
+                        filter: todo.done ? 'drop-shadow(0 1px 0 rgba(0,0,0,0.25))' : 'none',
+                        animation: todo.done ? 'check-pop 180ms ease-out' : 'none'
+                      }}
+                      aria-hidden="true"
+                    >
                       <polyline points="5 11 9 15 15 7" />
                     </svg>
-                    {/* Progress ring */}
-                    {holdId === todo.id && !todo.done && (
-                      <svg width="40" height="40" style={{ position: 'absolute', top: -4, left: -4, pointerEvents: 'none', zIndex: 1 }}>
-                        <circle
-                          cx="20" cy="20" r="17"
-                          stroke="#22c55e"
-                          strokeWidth="3.5"
-                          fill="none"
-                          strokeDasharray={2 * Math.PI * 17}
-                          strokeDashoffset={2 * Math.PI * 17 * (1 - holdProgress / 100)}
-                          style={{
-                            transition: 'stroke-dashoffset 0.1s linear',
-                            transform: 'rotate(-90deg)',
-                            transformOrigin: '50% 50%'
-                          }}
-                        />
-                      </svg>
-                    )}
                   </button>
                   <div style={{ marginLeft: 4, flex: 1, minWidth: 0 }}>
                     <div style={{
@@ -401,24 +331,22 @@ function TodoWidget() {
                       </div>
                     )}
                   </div>
-                  {todo.source !== 'canvas' && (
-                    <button onClick={() => deleteTodo(todo.id)} style={{
-                      marginLeft: 10,
-                      background: "#fff",
-                      border: "1.5px solid #f87171",
-                      color: "#f87171",
-                      borderRadius: 8,
-                      fontSize: 16,
-                      fontWeight: 600,
-                      width: 32,
-                      height: 32,
-                      display: "flex",
-                      alignItems: "center",
-                      justifyContent: "center",
-                      cursor: "pointer",
-                      transition: "background 0.2s, color 0.2s, border 0.2s"
-                    }} title="Delete task">✕</button>
-                  )}
+                  <button onClick={() => deleteTodo(todo.id)} style={{
+                    marginLeft: 10,
+                    background: "#fff",
+                    border: "1.5px solid #f87171",
+                    color: "#f87171",
+                    borderRadius: 8,
+                    fontSize: 16,
+                    fontWeight: 600,
+                    width: 32,
+                    height: 32,
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "center",
+                    cursor: "pointer",
+                    transition: "background 0.2s, color 0.2s, border 0.2s"
+                  }} title="Delete task">✕</button>
                 </li>
               );
             })}

--- a/client/src/components/TodoWidget.jsx
+++ b/client/src/components/TodoWidget.jsx
@@ -9,7 +9,7 @@ function TodoWidget() {
   const holdInterval = useRef();
   const [fadingIds, setFadingIds] = useState([]);
   const [todos, setTodos] = useState([]);
-  const [loading, setLoading] = useState(true);
+  const [loading, setLoading] = useState(false); 
   const [error, setError] = useState(null);
   const [courseFilter, setCourseFilter] = useState("all");
   const [timeFilter, setTimeFilter] = useState("all");
@@ -27,22 +27,6 @@ function TodoWidget() {
     "COMPSCI 367": "#a78bfa",
     "(Custom)": "#e5e7eb"
   };
-
-  useEffect(() => {
-    fetch("/src/mock_canvas_todos.json")
-      .then((res) => {
-        if (!res.ok) throw new Error("Failed to load todos");
-        return res.json();
-      })
-      .then((data) => {
-        setTodos(data.map(t => ({ ...t, done: false, source: "canvas" })));
-        setLoading(false);
-      })
-      .catch((err) => {
-        setError(err.message);
-        setLoading(false);
-      });
-  }, []);
 
   // Filtering logic
   let filtered = [...todos];

--- a/client/src/test/TodoWidget.test.jsx
+++ b/client/src/test/TodoWidget.test.jsx
@@ -1,61 +1,57 @@
-
-import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import React from 'react';
 import TodoWidget from '../components/TodoWidget';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import "@testing-library/jest-dom/vitest";
 
-const mockTodos = [
-  {
-    id: 1,
-    title: 'Assignment 1',
-    course: 'SOFTENG 310',
-    dueDate: '2025-08-25T23:59:00Z',
-  },
-  {
-    id: 2,
-    title: 'Lab 2',
-    course: 'SOFTENG 306',
-    dueDate: '2025-08-22T17:00:00Z',
-  },
-];
-
-beforeEach(() => {
-  global.fetch = vi.fn(() =>
-    Promise.resolve({
-      ok: true,
-      json: () => Promise.resolve(mockTodos),
-    })
-  );
-});
-
 describe('TodoWidget', () => {
-  it('renders Add button and dropdowns', async () => {
-    const { container } = render(<TodoWidget />);
-    const utils = within(container);
-    await waitFor(() => expect(utils.getByText('Add')).toBeInTheDocument());
-    expect(utils.getByText('All Courses')).toBeInTheDocument();
-    expect(utils.getByText('All Dates')).toBeInTheDocument();
+  it('renders Add button and time filter (no categories)', async () => {
+    render(<TodoWidget />);
+    await waitFor(() => expect(screen.getByText('Add')).toBeInTheDocument());
+    expect(screen.getByText('All Dates')).toBeInTheDocument();
+    expect(screen.queryByText('All Courses')).not.toBeInTheDocument();
   });
 
-  it('can open and close the add modal', async () => {
-    const { container } = render(<TodoWidget />);
-    const utils = within(container);
-    await waitFor(() => expect(utils.getByText('Add')).toBeInTheDocument());
-    fireEvent.click(utils.getByText('Add'));
-    expect(utils.getByText('Add New Task')).toBeInTheDocument();
-    fireEvent.click(utils.getByTitle('Close'));
-    expect(utils.queryByText('Add New Task')).not.toBeInTheDocument();
+  it('can open and close the add modal (rendered via portal)', async () => {
+    render(<TodoWidget />);
+    await waitFor(() => expect(screen.getByText('Add')).toBeInTheDocument());
+    fireEvent.click(screen.getByText('Add'));
+    expect(screen.getByText('Add New Task')).toBeInTheDocument();
+    fireEvent.click(screen.getByTitle('Close'));
+    await waitFor(() => expect(screen.queryByText('Add New Task')).not.toBeInTheDocument());
   });
 
-  it('can add a new todo', async () => {
-    const { container } = render(<TodoWidget />);
-    const utils = within(container);
-    await waitFor(() => expect(utils.getByText('Add')).toBeInTheDocument());
-    fireEvent.click(utils.getByText('Add'));
-    fireEvent.change(utils.getByPlaceholderText('Task title...'), { target: { value: 'Test Task' } });
-    fireEvent.change(utils.getByLabelText('Category'), { target: { value: 'daily' } });
-    fireEvent.click(utils.getByText('Add Task'));
-    expect(utils.getByText('Test Task')).toBeInTheDocument();
+  it('can add a new todo with description and class', async () => {
+    render(<TodoWidget />);
+    fireEvent.click(screen.getByText('Add'));
+    fireEvent.change(screen.getByPlaceholderText('Task title...'), { target: { value: 'Test Task' } });
+    fireEvent.change(screen.getByPlaceholderText('Optional details...'), { target: { value: 'Some details' } });
+    fireEvent.change(screen.getByPlaceholderText('Class (optional)...'), { target: { value: 'SOFTENG 310' } });
+    fireEvent.click(screen.getByText('Add Task'));
+
+    await waitFor(() => expect(screen.getByText('Test Task')).toBeInTheDocument());
+    expect(screen.getByText('SOFTENG 310')).toBeInTheDocument();
+    expect(screen.getByText('Some details')).toBeInTheDocument();
+  });
+
+  it('clicking the check toggles done/undone and delete works', async () => {
+    render(<TodoWidget />);
+    // add a task
+    fireEvent.click(screen.getByText('Add'));
+    fireEvent.change(screen.getByPlaceholderText('Task title...'), { target: { value: 'Complete Me' } });
+    fireEvent.click(screen.getByText('Add Task'));
+    await waitFor(() => expect(screen.getByText('Complete Me')).toBeInTheDocument());
+
+    // toggle done (single click now)
+    fireEvent.click(screen.getByLabelText('Mark as done'));
+    expect(screen.getByText('Complete Me')).toHaveStyle({ textDecoration: 'line-through' });
+
+    // toggle back
+    fireEvent.click(screen.getByLabelText('Mark as undone'));
+    expect(screen.getByText('Complete Me')).not.toHaveStyle({ textDecoration: 'line-through' });
+
+    // delete
+    fireEvent.click(screen.getByTitle('Delete task'));
+    await waitFor(() => expect(screen.queryByText('Complete Me')).not.toBeInTheDocument());
   });
 });


### PR DESCRIPTION
**Summary**
This PR continues the TodoWidget refactor to remove Canvas integration and focus exclusively on user-created todos with a simpler model. It updates the Add Task form and list rendering, improves the done/undo interaction and visuals, removes the obsolete categories filter, and updates tests accordingly.

- Remove Canvas integration
  - Deleted all references to mock_canvas_todos.json.
  - Removed logic tied to source === "canvas" (e.g., delete restrictions).
  - Removed Canvas course color mapping and related UI.

- Data model (local state only; Supabase wiring will follow separately)
  - Todos now use: { id, title, description, due_date, class, done }.
  - due_date is stored in snake_case; class replaces course.

- UI
  - Add Task modal now includes fields:
    - Title (required)
    - Description (optional)
    - Due date (optional)
    - Class (optional)
  - List item displays:
    - Title (bold) with line-through and faded styling when completed.
    - Class (small text, plain; no color mapping).
    - Description (below; further faded when completed).
    - Due date (small text, if provided).
  - Categories filter removed; retained the time filter (All Dates, Today, Next 7/14 Days).
  - “Tick” button now shows an obvious state change when done:
    - Background turns green with thicker white check and subtle pop/shadow.
    - Single-click toggles done/undone (no long-press required).

- Behavior
  - Users can add, view, toggle done/undone, and delete any todo.
  - Immediate toggle + visual feedback; undo is a simple click.

- Accessibility
  - Toggle uses role="checkbox" and aria-checked to reflect state.
  - Icons remain decorative via aria-hidden where appropriate.

- Tests (client/src/test/TodoWidget.test.jsx)
  - Updated to remove Canvas assumptions and categories filter assertions.
  - Added coverage for:
    - Rendering Add button and time filter (no “All Courses” present).
    - Opening/closing the Add modal.
    - Adding a todo with description and class and seeing them rendered.
    - Toggling done/undone and verifying strikethrough (and delete).
  - Dropped any mocks related to Canvas/mock JSON.

**Acceptance criteria (clear, testable)**
- [x] TodoWidget no longer loads from Canvas mock JSON.
- [x] New todos require a title and may include description, due_date, and class.
- [x] Add Task modal includes fields for title, description, due date, class.
- [x] Todos can be added, displayed, marked as done/undone, and deleted.
- [x] Completed tasks show strikethrough + faded styling.
- [x] Updated tests cover new fields and removal of Canvas logic.